### PR TITLE
Save schema from current connection

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,13 +1,16 @@
 <?php
 use Cake\Core\Configure;
+use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Schema\Shell\Task\SchemaSaveTask;
 
 $configKey = 'Schema.autoSaveSchemaAfterMigrate';
 
 if (!Configure::check($configKey) || Configure::read($configKey) === true) {
-    EventManager::instance()->on('Migration.afterMigrate', function () {
+    EventManager::instance()->on('Migration.afterMigrate', function (Event $event) {
         $task = new SchemaSaveTask;
+        $input = $event->getSubject()->getManager()->getInput();
+        $task->params['connection'] = $input->getOption('connection');
         $task->interactive = false;
         $task->initialize();
         $task->loadTasks();

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -9,11 +9,10 @@ $configKey = 'Schema.autoSaveSchemaAfterMigrate';
 if (!Configure::check($configKey) || Configure::read($configKey) === true) {
     EventManager::instance()->on('Migration.afterMigrate', function (Event $event) {
         $task = new SchemaSaveTask;
-        $input = $event->getSubject()->getManager()->getInput();
-        $task->params['connection'] = $input->getOption('connection');
         $task->interactive = false;
         $task->initialize();
         $task->loadTasks();
-        $task->save();
+        $input = $event->getSubject()->getManager()->getInput();
+        $task->save(['connection' => $input->getOption('connection')]);
     });
 }


### PR DESCRIPTION
When running migrations on other connection than default, the plugins try to create the schema file from default connection. 
This PR set the schema.php to be the schema from the last connection used.
I use this to test new migrations and generate schema for fixtures (as seen on #1 )

Another option could be that rebuild schema ONLY when migrations are run in default connection (or only connections configured via app.php)
